### PR TITLE
Fix bar width for custom tokens

### DIFF
--- a/R/progress.r
+++ b/R/progress.r
@@ -319,6 +319,10 @@ pb_render <- function(self, private, tokens) {
     str <- sub(str, pattern = ":bytes", replacement = bytes)
   }
 
+  for (t in names(tokens)) {
+    str <- gsub(paste0(":", t), tokens[[t]], str, fixed = TRUE)
+  }
+
   if (private$has_token["bar"]) {
     bar_width <- nchar(sub(str, pattern = ":bar", replacement = ""))
     bar_width <- private$width - bar_width
@@ -332,10 +336,6 @@ pb_render <- function(self, private, tokens) {
                         collapse = private$chars$incomplete)
 
     str <- sub(":bar", paste0(complete, incomplete), str)
-  }
-
-  for (t in names(tokens)) {
-    str <- gsub(paste0(":", t), tokens[[t]], str, fixed = TRUE)
   }
 
   if (private$last_draw != str) {

--- a/tests/testthat/test-progress.R
+++ b/tests/testthat/test-progress.R
@@ -284,10 +284,31 @@ test_that("custom tokens", {
   })
 
   sout <- win_newline(
-    "\rfoo    [==-----]  25%",
-    "\rfoo    [====---]  50%",
-    "\rfoobar [=====--]  75%",
-    "\rfoobar [=======] 100%",
+    "\rfoo    [==----]  25%",
+    "\rfoo    [===---]  50%",
+    "\rfoobar [====--]  75%",
+    "\rfoobar [======] 100%",
+    "\n"
+  )
+
+  expect_equal(out, sout)
+})
+
+test_that("bar adepts to width of custom tokens", {
+  out <- get_output({
+    pb <- progress_bar$new(stream = stdout(), force = TRUE,
+                           show_after = 0, width = 20,
+                           format = ":what [:bar] :percent",
+                           clear = FALSE, total = 200)
+    pb$tick(50, tokens = list(what = "text"))
+    pb$tick(50, tokens = list(what = "long text"))
+    pb$tick(100, tokens = list(what = "text"))
+  })
+
+  sout <- win_newline(
+    "\rtext [==------]  25%",
+    "\rlong text [==-]  50%",
+    "\rtext [========] 100%",
     "\n"
   )
 


### PR DESCRIPTION
I've just moved the for loop in `pb_render` a few lines up and added a test. Had to touch the other test on custom tokens though: the output was 21 chars (one char too long).